### PR TITLE
Fix: Fix for Hugo Compatibility Issues in Base Template and Shortcodes

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -4,7 +4,7 @@ title = "LOW←TECH MAGAZINE"
 
 buildFuture = true
 buildDrafts = false
-paginate = 12
+pagination.pagerSize = 12
 
 DefaultContentLanguage = "en"
 pluralizelisttitles = "false"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,7 @@
 
 	<link rel="icon" href="{{ .Site.BaseURL }}icons/sun.svg">
 
-	{{ $style := resources.Get "/css/style.scss" | resources.ToCSS }}
+	{{ $style := resources.Get "/css/style.scss" | css.Sass }}
 	<link rel="stylesheet" href="{{ $style.Permalink }}">
 
 	{{- partial "feeds" . -}}

--- a/layouts/shortcodes/ref.html
+++ b/layouts/shortcodes/ref.html
@@ -2,7 +2,7 @@
 {{- with site.GetPage $path -}}
   {{- .Permalink -}}
 {{- else -}}
-  {{- with .Page.Sites.First.GetPage $path -}}
+  {{- with .Page.Sites.Default.GetPage $path -}}
     {{- .Permalink -}}
  {{/*  code to produce errors on not found  */}}
   {{- else -}}


### PR DESCRIPTION
Fix for Hugo Compatibility Issues in Base Template and Shortcodes

+ Updated `baseof.html` to use `css.Sass` instead of `resources.ToCSS` to fix compatibility with the latest Hugo version.
+ Modified `ref.html` shortcode to use `.Page.Sites.Default.GetPage` instead of `.Page.Sites.First.GetPage` for better page retrieval functionality, ensuring compatibility with newer Hugo versions