### PR TITLE
Fix layout shift by introducing width and height attributes to <img> tags

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -44,7 +44,7 @@ enableInlineShortcodes = true
   categories = '/:slug/'
 
 [params]
-  author = 'Kris De Decker'
+  author = { name = "Kris De Decker", email = "solar@lowtechmagazine.com" }
   newsletter = 'https://d69baa34.sibforms.com/serve/MUIEAJWIw9w82Dl4ua6FQArPaI-3Qb-zVTwPNabHQgFH51MiGF69Smy9LOC_HPoUmBj0emaXsXT87gcQXDPvtu-AZsJCHWhkkv21CdrcQu4GdnYAhZ-MrIPhwGDecagLzYxqfvkaqXg2ODcbJU4ByoDmzJK3ZTczDo2jcWtfn-En0MGKLVkgxx9TgdHqYoPabMJCMF-agLEclEwv'
   description = 'This is a solar-powered website, which means it sometimes goes offline'
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -4,7 +4,7 @@
 {{- $img = resources.Get $path -}}
 {{- end -}}
 {{- with $img -}}
-<img class="uncompressed" src="{{ $img.RelPermalink }}" alt="{{ $.Text }}" />
+<img class="uncompressed" src="{{ $img.RelPermalink }}" alt="{{ $.Text }}" width="{{ .Width }}" height="{{ .Height }}" />
 {{- else -}}
 <img class="uncompressed"  src="{{ .Destination | safeURL }}" alt="{{ $.Text }}" />{{- end -}}
 

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -20,9 +20,9 @@
     <link>{{ .Permalink }}</link>
     <description>{{i18n "sitesubtitle" | default .Site.Params.description}}</description>
     <generator>Hugo {{hugo.Version}}</generator>{{ with .Site.Language.Lang }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{- with .OutputFormats.Get "RSS" -}}
@@ -41,7 +41,7 @@
       <enclosure url="{{  .Site.BaseURL }}icons/sun.svg }}" type="image/png" length=""></enclosure>
       {{- end -}}
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{  .Content | html }}</description>
     </item>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -9,7 +9,7 @@
 {{- $alt  := .Inner -}}
 <div class="article-img {{if le $img.Width (mul $img.Height 1.2)}} vertical{{end}}">
 <figure data-imgstate="dither">
-<img src="{{with $dithered_image }}{{ .Permalink }}{{end}}" alt='{{ with $alt }}{{ $alt | markdownify| plainify }}{{ else }}{{ .Get "alt" }}{{ . | markdownify| plainify }}{{ end }}' data-original="{{if $thumb}}{{$thumb.Permalink}}{{else}}images/{{$old_filename }}{{end}}" data-dither="{{with $dithered_image }}{{ .RelPermalink }}{{end}}" loading="lazy"/> </figure>
+<img src="{{with $dithered_image }}{{ .Permalink }}{{end}}" alt='{{ with $alt }}{{ $alt | markdownify| plainify }}{{ else }}{{ .Get "alt" }}{{ . | markdownify| plainify }}{{ end }}' data-original="{{if $thumb}}{{$thumb.Permalink}}{{else}}images/{{$old_filename }}{{end}}" data-dither="{{with $dithered_image }}{{ .RelPermalink }}{{end}}" width="{{$img.Width}}" height="{{$img.Height}}" loading="lazy"/> </figure>
 <div class="figure-controls">
 <figcaption class="caption">
 
@@ -36,7 +36,7 @@
 {{- $alt  := .Inner -}}
 <div class="article-img">
 <figure data-imgstate="dither">
-<img src="{{with $dithered_image }}{{ .Permalink }}{{end}}" alt='{{ with $alt }}{{ $alt | markdownify| plainify }}{{ else }}{{ .Get "alt" }}{{ . | markdownify| plainify }}{{ end }}' data-original="images/{{$old_filename }}" data-dither="{{with $dithered_image }}{{ .Permalink }}{{end}}" loading="lazy"/> </figure>
+<img src="{{with $dithered_image }}{{ .Permalink }}{{end}}" alt='{{ with $alt }}{{ $alt | markdownify| plainify }}{{ else }}{{ .Get "alt" }}{{ . | markdownify| plainify }}{{ end }}' data-original="images/{{$old_filename }}" data-dither="{{with $dithered_image }}{{ .Permalink }}{{end}}" {{with $dithered_image}}width="{{.Width}}" height="{{.Height}}"{{end}} loading="lazy"/> </figure>
 <div class="figure-controls">
 <figcaption class="caption">
 


### PR DESCRIPTION
This PR actually does two things, seperated into the two commits. (Sorry)

The commit messages explains in some detail why you want this but I will repost them here:

This fixes an annoyance where when images load in they shift the text
around. This is specifically annoying on slower internet speeds or when trying
to reload the page on certain devices and it taking you to a different part of
the text because of the layout changes cause by loading images.

Now the browser should reserve the space the images will later occupy so no late
update occurs.

AND

For some reason on the recent version of hugo on my laptop the previous code
wasn't working so I had to add Params in there and in the hugo.toml I had to
change the format of the author field.

I really appreciate all the work you do on the magazine and this is a slight annoyance to me that I'm hoping can be fixed and make the reader's experience more enjoyable!!